### PR TITLE
feat(highlights): show source channel name

### DIFF
--- a/wires/plugins/highlights/plugin.py
+++ b/wires/plugins/highlights/plugin.py
@@ -113,13 +113,17 @@ async def on_message(event: hikari.GuildMessageCreateEvent) -> None:
     guild = unwrap(event.get_guild())
     for user, triggers in notifications.items():
         channel = await plugin.app.rest.create_dm_channel(user)
+        footer = guild.name
+        if (source_channel := event.get_channel()):
+            if (source_channel_name := source_channel.name):
+                footer += f" | {source_channel_name}"
         embed = (
             hikari.Embed(
                 title="Jump",
                 description=event.content,
                 url=event.message.make_link(event.guild_id),
             )
-            .set_footer(guild.name, icon=guild.icon_url)
+            .set_footer(footer, icon=guild.icon_url)
             .set_author(name=event.author.username, icon=event.author.avatar_url)
         )
         await channel.send(f"Highlights triggered: {', '.join(triggers)}", embed=embed)

--- a/wires/plugins/highlights/plugin.py
+++ b/wires/plugins/highlights/plugin.py
@@ -111,19 +111,19 @@ async def on_message(event: hikari.GuildMessageCreateEvent) -> None:
         notifications.setdefault(hl.user_id, []).append(clip(hl.content, 12))
 
     guild = unwrap(event.get_guild())
+    footer = guild.name
+    if (source_channel := event.get_channel()) and source_channel.name:
+        footer += f" | {source_channel.name}"
+    embed = (
+        hikari.Embed(
+            title="Jump",
+            description=event.content,
+            url=event.message.make_link(event.guild_id),
+        )
+        .set_footer(footer, icon=guild.icon_url)
+        .set_author(name=event.author.username, icon=event.author.avatar_url)
+    )
+
     for user, triggers in notifications.items():
         channel = await plugin.app.rest.create_dm_channel(user)
-        footer = guild.name
-        if (source_channel := event.get_channel()):
-            if (source_channel_name := source_channel.name):
-                footer += f" | {source_channel_name}"
-        embed = (
-            hikari.Embed(
-                title="Jump",
-                description=event.content,
-                url=event.message.make_link(event.guild_id),
-            )
-            .set_footer(footer, icon=guild.icon_url)
-            .set_author(name=event.author.username, icon=event.author.avatar_url)
-        )
         await channel.send(f"Highlights triggered: {', '.join(triggers)}", embed=embed)


### PR DESCRIPTION
Adds the source channel name (if available) to the footer of the highlight
notification embed. This is done to make it easier to identify where the
highlight comes from (currently, it is necessary to Jump to the message and then
check the highlight there).

These changes are completely untested.